### PR TITLE
Fix UI manager references and upgrade screen flow

### DIFF
--- a/Gamblers Revenge/Assets/Scripts/PlayerController.cs
+++ b/Gamblers Revenge/Assets/Scripts/PlayerController.cs
@@ -69,7 +69,7 @@ public class PlayerController : MonoBehaviour
         string[] optionNames = picks.Select(u => u.ToString()).ToArray();
 
         // 3) show UI
-        UIManager.instance.ShowUpgradeScreen(optionNames, choice =>
+        UpgradeManager.instance.ShowUpgradeScreen(optionNames, choice =>
         {
             // 4) apply the picked upgrade
             UpgradeEffects.UpgradeType chosen = picks[choice];

--- a/Gamblers Revenge/Assets/Scripts/UIManager.cs
+++ b/Gamblers Revenge/Assets/Scripts/UIManager.cs
@@ -12,6 +12,8 @@ public class UIManager : MonoBehaviour
     [Header("In-Game HUD")]
     public Image hpBar;
     public TMP_Text levelText, pointsText, healthText;
+    public TMP_Text scoreText, highScoreText;
+
     Health playerHealth;
     void Awake()
     {
@@ -22,8 +24,9 @@ public class UIManager : MonoBehaviour
 
     void Start()
     {
-        playerHealth = PlayerController.instance.GetComponent<Health>();
-        
+        if (PlayerController.instance != null)
+            playerHealth = PlayerController.instance.GetComponent<Health>();
+
     }
 
     void Update()
@@ -41,10 +44,19 @@ public class UIManager : MonoBehaviour
             return;
         }
 
+        if (playerHealth == null)
+            playerHealth = PlayerController.instance.GetComponent<Health>();
+
+        if (playerHealth == null)
+        {
+            hpBar.fillAmount = 0f;
+            return;
+        }
+
         hpBar.fillAmount = playerHealth.curHp / playerHealth.maxHp;
         levelText.text = "Level: " + PlayerController.instance.level;
-        pointsText.text = "Points: " 
-                            + PlayerController.instance.points 
+        pointsText.text = "Points: "
+                            + PlayerController.instance.points
                             + "/" + PlayerController.instance.maxPoints;
         healthText.text = $"{playerHealth.curHp}/{playerHealth.maxHp}";
     }

--- a/Gamblers Revenge/Assets/Scripts/UpgradeManager.cs
+++ b/Gamblers Revenge/Assets/Scripts/UpgradeManager.cs
@@ -16,6 +16,8 @@ public class UpgradeManager : MonoBehaviour
     [Tooltip("The Text component on each of those buttons")]
     public TMP_Text[] upgradeButtonTexts;     // size = 3
 
+    private Action<int> onUpgradeChosen;
+
     void Awake()
     {
         // singleton
@@ -62,6 +64,7 @@ public class UpgradeManager : MonoBehaviour
     {
         // hide UI
         upgradeScreen.SetActive(false);
+        Time.timeScale = 1f; // Resume the game
 
         // invoke the callback
         onUpgradeChosen?.Invoke(idx);


### PR DESCRIPTION
## Summary
- add score and high-score text fields to UI manager and guard against missing player health
- store upgrade callbacks and resume time when player selects an upgrade
- route level-up upgrade UI through `UpgradeManager`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_6893b15ec19c83209c5aa2158c1c184f