### PR TITLE
Refactor health singleton into player-specific component

### DIFF
--- a/Gamblers Revenge/Assets/Scripts/Health.cs
+++ b/Gamblers Revenge/Assets/Scripts/Health.cs
@@ -4,30 +4,15 @@ using UnityEngine;
 
 public class Health : MonoBehaviour
 {
-    //singleton
-    public static Health instance; // Singleton instance of the Health class
-    public static Health GetInstance()
-    {
-        if (instance == null)
-        {
-            instance = FindObjectOfType<Health>();
-            if (instance == null)
-            {
-                GameObject obj = new GameObject("Health");
-                instance = obj.AddComponent<Health>();
-            }
-        }
-        return instance;
-    }
     public float maxHp = 10f; // Maximum health of the object
     public float curHp = 0f;
+
     // Start is called before the first frame update
     void Start()
     {
         curHp = maxHp; // Initialize current health to maximum health
     }
 
-    // Update is called once per frame
     public void TakeDamage(float amt)
     {
         curHp -= amt; // Decrease current health by the amount of damage taken

--- a/Gamblers Revenge/Assets/Scripts/UpgradeEffects.cs
+++ b/Gamblers Revenge/Assets/Scripts/UpgradeEffects.cs
@@ -51,8 +51,9 @@ public class UpgradeEffects : MonoBehaviour
 
     public void IncreaseMaxHealth()
     {
-        Health.instance.maxHp += 1;
-        Health.instance.curHp += 1;
+        Health playerHealth = PlayerController.instance.GetComponent<Health>();
+        playerHealth.maxHp += 1;
+        playerHealth.curHp += 1;
     }
 
     public void ApplyUpgrade(UpgradeType upgradeType)


### PR DESCRIPTION
## Summary
- remove global Health singleton and treat Health as a regular component
- target player's Health component when applying MaxHealth upgrades

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893d264327c832081f3d4abd9f7f7e3