### PR TITLE
Reset fire timer only when attack occurs

### DIFF
--- a/Gamblers Revenge/Assets/Scripts/Sword.cs
+++ b/Gamblers Revenge/Assets/Scripts/Sword.cs
@@ -22,11 +22,11 @@ public class Sword : Weapon
 
 
     // Start is called before the first frame update
-    public override void Attack()
+    public override bool Attack()
     {
         if (Input.GetMouseButton(1) == false)
         {
-            return;
+            return false;
         }
         //anim.SetTrigger("SwordSlash");
         Vector2 mousePos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
@@ -44,8 +44,6 @@ public class Sword : Weapon
         rb.velocity = shootDir.normalized * slashSpeed;
         slash.GetComponent<Projectile>().damage = damage;
 
-
-
-
+        return true;
     }
 }

--- a/Gamblers Revenge/Assets/Scripts/SwordSlices.cs
+++ b/Gamblers Revenge/Assets/Scripts/SwordSlices.cs
@@ -10,11 +10,11 @@ public class SwordSlices : Weapon
     {
         shotSpeed = PlayerController.instance.shotSpeed;
     }
-    public override void Attack()
+    public override bool Attack()
     {
         if (Input.GetMouseButton(0) == false)
         {
-            return;
+            return false;
         }
         Vector2 mousePos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
         Vector2 shootDir = mousePos - (Vector2)transform.position;
@@ -34,6 +34,7 @@ public class SwordSlices : Weapon
         Rigidbody2D rb = g.GetComponent<Rigidbody2D>();
         rb.velocity = shootDir.normalized * shotSpeed;
         g.GetComponent<Projectile>().damage = damage;
+        return true;
     }
 
 }

--- a/Gamblers Revenge/Assets/Scripts/Weapon.cs
+++ b/Gamblers Revenge/Assets/Scripts/Weapon.cs
@@ -8,9 +8,10 @@ public class Weapon : MonoBehaviour
     public float fireRate = 1.5f;
     public float fireTimer = 1.5f;
 
-    public virtual void Attack()
+    public virtual bool Attack()
     {
         print("Parent attack!");
+        return true;
     }
 
 
@@ -23,10 +24,10 @@ public class Weapon : MonoBehaviour
         }
         else
         {
-            
-                Attack(); // Call the attack method
-                fireTimer = fireRate; // Reset the timer
-            
+            if (Attack()) // Call the attack method
+            {
+                fireTimer = fireRate; // Reset the timer only if attack was performed
+            }
         }
        
     }


### PR DESCRIPTION
## Summary
- Reset weapon fire timer only when an attack is actually executed
- Have `Attack()` return whether it fired and update sword subclasses accordingly

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893d26243b083209c3d13da509ee189