### PR TITLE
Match class names to script filenames

### DIFF
--- a/Gamblers Revenge/Assets/Scripts/EnemyAI/GhostAI.cs
+++ b/Gamblers Revenge/Assets/Scripts/EnemyAI/GhostAI.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Ghost : MonoBehaviour
+public class GhostAI : MonoBehaviour
 {
     private void OnCollisionEnter2D(Collision2D collision)
     {

--- a/Gamblers Revenge/Assets/Scripts/EnemyAI/GolemiteAI.cs
+++ b/Gamblers Revenge/Assets/Scripts/EnemyAI/GolemiteAI.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Golemite : MonoBehaviour
+public class GolemiteAI : MonoBehaviour
 {
     
     private void OnCollisionEnter2D(Collision2D collision)

--- a/Gamblers Revenge/Assets/Scripts/EnemyAI/WerewolfAI.cs
+++ b/Gamblers Revenge/Assets/Scripts/EnemyAI/WerewolfAI.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Werewolf : MonoBehaviour
+public class WerewolfAI : MonoBehaviour
 {
     
     private void OnCollisionEnter2D(Collision2D collision)


### PR DESCRIPTION
## Summary
- Rename GhostAI, GolemiteAI, and WerewolfAI classes to match their file names for proper Unity recognition.

## Testing
- `mcs Assets/Scripts/EnemyAI/GhostAI.cs` *(fails: command not found)*
- `sudo apt-get install -y mono-mcs` *(fails: Unable to locate package mono-mcs)*

------
https://chatgpt.com/codex/tasks/task_e_6893d262616c8320a23e9be67a34d2a2