### PR TITLE
Fix null references in UI and leveling systems

### DIFF
--- a/Gamblers Revenge/Assets/Scripts/PlayerController.cs
+++ b/Gamblers Revenge/Assets/Scripts/PlayerController.cs
@@ -60,9 +60,16 @@ public class PlayerController : MonoBehaviour
         level++;
         points = 0;
         maxPoints = Mathf.RoundToInt(maxPoints * 1.5f);
-        FindObjectOfType<SpawnManagerWerewolf>().spawnRate *= 0.8f;
-        FindObjectOfType<SpawnManagerGolemite>().spawnRate *= 0.8f;
-        FindObjectOfType<SpawnManagerGhost>().spawnRate *= 0.8f;
+
+        // Lower enemy spawn rates for all active spawn managers if they exist
+        foreach (var spawner in FindObjectsOfType<SpawnManagerWerewolf>())
+            spawner.spawnRate *= 0.8f;
+
+        foreach (var spawner in FindObjectsOfType<SpawnManagerGolemite>())
+            spawner.spawnRate *= 0.8f;
+
+        foreach (var spawner in FindObjectsOfType<SpawnManagerGhost>())
+            spawner.spawnRate *= 0.8f;
 
         // 2) pick 3 random upgrades
         List<UpgradeEffects.UpgradeType> picks = UpgradeEffects.instance.ChooseUpgrades();

--- a/Gamblers Revenge/Assets/Scripts/UIManager.cs
+++ b/Gamblers Revenge/Assets/Scripts/UIManager.cs
@@ -26,8 +26,8 @@ public class UIManager : MonoBehaviour
 
     void Start()
     {
-        playerHealth = PlayerController.instance.GetComponent<Health>();
-        
+        if (PlayerController.instance != null)
+            playerHealth = PlayerController.instance.GetComponent<Health>();
     }
 
     void Update()
@@ -39,18 +39,32 @@ public class UIManager : MonoBehaviour
             highScoreText.text = "High Score: " + GameManager.instance.highScore;*/
 
         // Update HUD
-        if (PlayerController.instance == null)
+        var player = PlayerController.instance;
+        if (player == null)
         {
-            hpBar.fillAmount = 0f;
+            if (hpBar != null)
+                hpBar.fillAmount = 0f;
             return;
         }
 
-        hpBar.fillAmount = playerHealth.curHp / playerHealth.maxHp;
-        levelText.text = "Level: " + PlayerController.instance.level;
-        pointsText.text = "Points: " 
-                            + PlayerController.instance.points 
-                            + "/" + PlayerController.instance.maxPoints;
-        healthText.text = $"{playerHealth.curHp}/{playerHealth.maxHp}";
+        if (playerHealth == null)
+            playerHealth = player.GetComponent<Health>();
+
+        if (playerHealth == null)
+        {
+            if (hpBar != null)
+                hpBar.fillAmount = 0f;
+            return;
+        }
+
+        if (hpBar != null)
+            hpBar.fillAmount = playerHealth.curHp / playerHealth.maxHp;
+        if (levelText != null)
+            levelText.text = "Level: " + player.level;
+        if (pointsText != null)
+            pointsText.text = "Points: " + player.points + "/" + player.maxPoints;
+        if (healthText != null)
+            healthText.text = $"{playerHealth.curHp}/{playerHealth.maxHp}";
     }
     
 


### PR DESCRIPTION
## Summary
- Scale down spawn rates for every active spawn manager on level-up
- Update HUD elements only when player and relevant UI fields are present

## Testing
- `dotnet test` (fails: command not found)
- `apt-get update` (fails: repository not signed)
- `apt-get install -y dotnet-sdk-8.0` (fails: package not found)


------
https://chatgpt.com/codex/tasks/task_e_6893e4bcd8b48320b9b7452db74cf037