### PR TITLE
Add HUD and game over screen with upgrade selection

### DIFF
--- a/Gamblers Revenge/Assets/Scripts/Health.cs
+++ b/Gamblers Revenge/Assets/Scripts/Health.cs
@@ -49,6 +49,7 @@ public class Health : MonoBehaviour
                 anim.SetBool("Alive", false);
                 PlayerController.instance.speed= 0f;
                 await Task.Delay(2000);
+                UIManager.instance?.ShowLoseScreen();
                 Destroy(gameObject);
             }
             else

--- a/Gamblers Revenge/Assets/Scripts/UIManager.cs
+++ b/Gamblers Revenge/Assets/Scripts/UIManager.cs
@@ -11,8 +11,13 @@ public class UIManager : MonoBehaviour
 
     [Header("In-Game HUD")]
     public Image hpBar;
+    public Image xpBar;
     public TMP_Text levelText, pointsText, healthText;
+    public TMP_Text scoreText, highScoreText;
     Health playerHealth;
+
+    [Header("Lose Screen")]
+    public GameObject loseScreen;
 
     // A callback that your game logic can set to handle the chosen upgrade (0‒2)
     
@@ -28,15 +33,17 @@ public class UIManager : MonoBehaviour
     {
         if (PlayerController.instance != null)
             playerHealth = PlayerController.instance.GetComponent<Health>();
+        if (loseScreen != null)
+            loseScreen.SetActive(false);
     }
 
     void Update()
     {
         // Update score & high score
-        /*if (scoreText != null)
+        if (scoreText != null)
             scoreText.text = "Score: " + GameManager.instance.score;
         if (highScoreText != null)
-            highScoreText.text = "High Score: " + GameManager.instance.highScore;*/
+            highScoreText.text = "High Score: " + GameManager.instance.highScore;
 
         // Update HUD
         var player = PlayerController.instance;
@@ -59,6 +66,8 @@ public class UIManager : MonoBehaviour
 
         if (hpBar != null)
             hpBar.fillAmount = playerHealth.curHp / playerHealth.maxHp;
+        if (xpBar != null)
+            xpBar.fillAmount = (float)player.points / player.maxPoints;
         if (levelText != null)
             levelText.text = "Level: " + player.level;
         if (pointsText != null)
@@ -66,15 +75,24 @@ public class UIManager : MonoBehaviour
         if (healthText != null)
             healthText.text = $"{playerHealth.curHp}/{playerHealth.maxHp}";
     }
-    
+
 
     public void Restart()
     {
+        Time.timeScale = 1f;
         SceneManager.LoadScene(SceneManager.GetActiveScene().name);
     }
 
     public void MainMenu()
     {
+        Time.timeScale = 1f;
         SceneManager.LoadScene("MainMenu");
+    }
+
+    public void ShowLoseScreen()
+    {
+        if (loseScreen != null)
+            loseScreen.SetActive(true);
+        Time.timeScale = 0f;
     }
 }


### PR DESCRIPTION
## Summary
- Expand UI manager with XP bar, score/high score display and lose screen controls
- Show lose screen when the player dies and reset timescale on restart
- Existing level up system pauses the game and presents three upgrade choices

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_6894129566d8832091ef9b5e61798b3b