### PR TITLE
Hide upgrade screen on scene load

### DIFF
--- a/Gamblers Revenge/Assets/Scripts/UpgradeManager.cs
+++ b/Gamblers Revenge/Assets/Scripts/UpgradeManager.cs
@@ -61,7 +61,7 @@ public class UpgradeManager : MonoBehaviour
 
         upgradeScreen.SetActive(true);
     }
-     private void OnUpgradeButton(int idx)
+    private void OnUpgradeButton(int idx)
     {
         // hide UI
         upgradeScreen.SetActive(false);
@@ -73,5 +73,17 @@ public class UpgradeManager : MonoBehaviour
         onUpgradeChosen?.Invoke(idx);
 
         onUpgradeChosen = null;
+    }
+
+    // Ensure the upgrade screen starts hidden in every scene
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    static void HideOnSceneLoad()
+    {
+        var screen = GameObject.Find("UpgradeScreen");
+        if (screen != null)
+        {
+            screen.SetActive(false);
+            Time.timeScale = 1f;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Automatically hide upgrade screen when a scene loads
- Reset time scale to ensure gameplay resumes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68941897d3b88320a4b49a39a030de82