### PR TITLE
fix: avoid null reference when leveling

### DIFF
--- a/Gamblers Revenge/Assets/Scripts/PlayerController.cs
+++ b/Gamblers Revenge/Assets/Scripts/PlayerController.cs
@@ -72,7 +72,7 @@ public class PlayerController : MonoBehaviour
             spawner.spawnRate *= 0.8f;
 
         // 2) pick 3 random upgrades
-        List<UpgradeEffects.UpgradeType> picks = UpgradeEffects.instance.ChooseUpgrades();
+        List<UpgradeEffects.UpgradeType> picks = UpgradeEffects.Instance.ChooseUpgrades();
         string[] optionNames = picks.Select(u => u.ToString()).ToArray();
 
         // 3) show UI
@@ -80,7 +80,7 @@ public class PlayerController : MonoBehaviour
         {
             // 4) apply the picked upgrade
             UpgradeEffects.UpgradeType chosen = picks[choice];
-            UpgradeEffects.instance.ApplyUpgrade(chosen);
+            UpgradeEffects.Instance.ApplyUpgrade(chosen);
 
             _awaitingUpgrade = false;
         });

--- a/Gamblers Revenge/Assets/Scripts/UpgradeEffects.cs
+++ b/Gamblers Revenge/Assets/Scripts/UpgradeEffects.cs
@@ -3,18 +3,33 @@ using UnityEngine;
 
 public class UpgradeEffects : MonoBehaviour
 {
+    private static UpgradeEffects _instance;
 
-    //singleton instance
-    public static UpgradeEffects instance;
+    public static UpgradeEffects Instance
+    {
+        get
+        {
+            if (_instance == null)
+            {
+                _instance = FindObjectOfType<UpgradeEffects>();
+                if (_instance == null)
+                {
+                    GameObject obj = new GameObject("UpgradeEffects");
+                    _instance = obj.AddComponent<UpgradeEffects>();
+                }
+            }
+            return _instance;
+        }
+    }
+
     private void Awake()
     {
-        // Ensure only one instance exists
-        if (instance == null)
+        if (_instance == null)
         {
-            instance = this;
+            _instance = this;
             DontDestroyOnLoad(gameObject);
         }
-        else
+        else if (_instance != this)
         {
             Destroy(gameObject);
         }


### PR DESCRIPTION
## Summary
- replace UpgradeEffects public field & method with singleton property that auto-creates an object if missing
- update PlayerController to reference UpgradeEffects.Instance when choosing/applying upgrades

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68942070c68c83208e31f960c8c9c263