### PR TITLE
Add logic for max HP upgrade

### DIFF
--- a/Gamblers Revenge/Assets/Scripts/UpgradeEffects.cs
+++ b/Gamblers Revenge/Assets/Scripts/UpgradeEffects.cs
@@ -66,8 +66,19 @@ public class UpgradeEffects : MonoBehaviour
 
     public void IncreaseMaxHealth()
     {
-        //agent edit here
-        
+        // Get the player's Health component and increase both max and current HP
+        var player = PlayerController.instance;
+        if (player == null)
+            return;
+
+        var health = player.GetComponent<Health>();
+        if (health == null)
+            return;
+
+        // Increase the player's maximum health and heal to full
+        health.maxHp += 5f;
+        health.curHp = health.maxHp;
+
     }
 
     public void ApplyUpgrade(UpgradeType upgradeType)


### PR DESCRIPTION
## Summary
- Implement `IncreaseMaxHealth` in `UpgradeEffects` to boost player's max health and restore HP

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894c63bcbfc83208b41172647b97759