### PR TITLE
Add component for displaying enemy HP bars

### DIFF
--- a/Gamblers Revenge/Assets/Scripts/EnemyHP.cs
+++ b/Gamblers Revenge/Assets/Scripts/EnemyHP.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple helper that keeps an enemy health slider in sync with its
+/// <see cref="Health"/> component.  Attach this to an enemy alongside a
+/// <c>Health</c> component and assign a <c>HPSlider</c> in the inspector.
+/// </summary>
+public class EnemyHP : MonoBehaviour
+{
+    [SerializeField] private HPSlider hpSlider;
+    private Health health;
+
+    void Awake()
+    {
+        health = GetComponent<Health>();
+    }
+
+    void Start()
+    {
+        if (hpSlider != null && health != null)
+        {
+            hpSlider.SetMaxHealth(health.maxHp);
+        }
+    }
+
+    void Update()
+    {
+        if (hpSlider != null && health != null)
+        {
+            hpSlider.SetHealth(health.curHp);
+        }
+    }
+}
+

--- a/Gamblers Revenge/Assets/Scripts/EnemyHP.cs.meta
+++ b/Gamblers Revenge/Assets/Scripts/EnemyHP.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bf55b941c5d46ebad572da827f606ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add EnemyHP script to sync enemy `Health` with an assigned `HPSlider`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e84c11588320a5913ac786c82521